### PR TITLE
Example of Catalog Plugin using GraphQL & YAML based plugin system 

### DIFF
--- a/examples/catalog/CatalogServicesLayout.yaml
+++ b/examples/catalog/CatalogServicesLayout.yaml
@@ -1,0 +1,67 @@
+apiVersion: backstage.io/v1alpha1
+kind: Layout
+metadata:
+  name: CatalogServices
+queries:
+  data:
+    query:
+      $file: ./CatalogServicesQuery.graphql
+    variables:
+      q: ${{ params.q }}
+      pageSize: ${{ params.pageSize }}
+      cursor: ${{ params.cursor }}
+mutations:
+  toggleFavorite:
+    $file: ./ToggleFavoriteMutation.graphql
+content:
+  # see: https://github.com/backstage/backstage/blob/master/plugins/catalog/src/components/CatalogTable/CatalogTable.tsx
+  - component: container
+    content:
+      - component: Box
+        xs: 6
+        content: Systems
+      - component: Box
+        xs: 6
+        content:
+          - component: FilterInput
+            submit: "${{ page.navigate({ q: input }) }}"
+  - component: Table
+    isLoading: ${{ queries.data.loading }}
+    items: ${{ queries.data.nodes }}
+    columns:
+      - title: Name
+        content: ${{ item.name }}
+      - title: System
+        content:
+          - component: Link
+            content: ${{ item.system.name }}
+            to: ${{ item.system.url }}
+      - title: Owner
+        content:
+          - component: Link
+            content: ${{ item.owner.name }}
+            to: ${{ item.owner.url }}
+      - title: Lifecycle
+        content: ${{ item.lifecycle }}
+      - title: Description
+        content: ${{ item.description }}
+      - title: Tags
+        content: 
+          - component: List
+            yield: # called for each item in the list
+              - component: Chip
+                content: ${{ item }}
+      - title: Actions
+        content:
+          - component: IconLink
+            icon: view
+            tooltip: View
+            to: ${{ item.url }}
+          - component: IconLink
+            icon: edit
+            tooltip: Edit
+            to: ${{ item.editUrl }}
+          - component: IconLink
+            icon: star
+            fill: ${{ "yellow" if item.favorite }}
+            click: ${{ mutations.toggleFavorite(item.ref) }} 

--- a/examples/catalog/CatalogServicesQuery.graphql
+++ b/examples/catalog/CatalogServicesQuery.graphql
@@ -1,0 +1,23 @@
+query CatalogSystemsQuery($q: String, $cursor: String, $pageSize: Int = 100) {
+  catalog(first: $pageSize, after: $cursor, q: $q) {
+    nodes {
+      ... on SystemComponent {
+        name
+        ref
+        url
+        editUrl
+        description
+        favorite
+        owner {
+          name
+          url
+        }
+        system {
+          name
+          url
+        }
+
+      }
+    }
+  }
+}

--- a/examples/catalog/README.md
+++ b/examples/catalog/README.md
@@ -1,0 +1,69 @@
+# Catalog Plugin Example
+
+This is an example of a hypothetical plugin that has similar functionality to the Catalog plugin but uses GraphQL for fetching data and data-driven rendering. This example has the following composite parts,
+
+## Why YAML and not JSX?
+
+The goal of this architecture is to allow people who're not familiar with React/TypeScript to build performant applications using their company's design system. These people may be SREs, IT people, Product Managers or developers of various experience levels. YAML is the lowest common denominator that everyone is familiar with. YAML is standard in the Cloud Native ecosystem.
+
+## Why GraphQL?
+
+* GraphQL query syntax is a good balance between flexibility and expressiveness.
+* GraphQL SDL is concice.
+* GraphQL ecosystem provides tools that allow extending the GraphQL SDL with domain-specific features.
+* GraphQL ecosystem includes clients that provide an in-memory cache that can be used to synchronize data across multiple components that use the same data.
+
+## API
+
+1. `kind: Plugin` - describes routes provided by this plugin and layouts rendered by each route.
+2. `kind: Layout` - describes queries and mutations used by the React components and tree of components.
+
+### kind: Plugin
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Plugin
+routes:
+  services:
+    queryParams: # query parameters used by this route - will be merged into params.
+      pageSize:
+        - type: number
+      cursor:
+        - type: string
+      q:
+        - type: string
+    layout: # reference to `kind: Layout`
+      $file: ./CatalogServicesLayout.yaml
+  "services/:namespace/:name":
+    params: # will be available on `params` inthe template
+      namespace:
+        type: string
+      name:
+        type: string
+    # TODO
+    # layout:
+    #   $file: ./CatalogServiceEntityPage.yaml
+```
+
+### kind: Layout
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Layout
+metadata:
+  name: CatalogServices
+queries:
+  data:
+    query:
+      $file: ./CatalogServicesQuery.graphql
+    variables:
+      q: ${{ params.q }}
+      pageSize: ${{ params.pageSize }}
+      cursor: ${{ params.cursor }}
+mutations:
+  toggleFavorite:
+    $file: ./ToggleFavoriteMutation.graphql
+content:
+  # tree of components with their mapping
+```
+

--- a/examples/catalog/ToggleFavoriteMutation.graphql
+++ b/examples/catalog/ToggleFavoriteMutation.graphql
@@ -1,0 +1,7 @@
+mutation ToggleFavoriteMutation($entityRef: String) {
+  toggleFavorite(entityRef: $entityRef) {
+    ... on Component {
+      favorite
+    }
+  }
+}

--- a/examples/catalog/plugin.yaml
+++ b/examples/catalog/plugin.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: Plugin
+routes:
+  services:
+    params:
+      pageSize:
+        - type: number
+      cursor:
+        - type: string
+      q:
+        - type: string
+    layout:
+      $file: ./CatalogServicesLayout.yaml
+    


### PR DESCRIPTION
# Motivation

Share my thoughts on what a plugin system might look like that would allow the following,

1. Make it easier for people unfamiliar with React/TypeScript to write good UIs
2. Allow plugins to be installable without a build step
3. Allow plugins to be installed using an approach similar to `kube apply` or importing entities into the catalog.

# Approach

Checkout [examples/catalog/README.md](https://github.com/taras/backstage-synthesizer/tree/catalog-example-spike/examples/catalog/README.md) for more information